### PR TITLE
Fix LCD_RTS.{h,cpp} for case-sensitive systems.

### DIFF
--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.cpp
@@ -1,5 +1,5 @@
-#include "lcd_rts.h"
-#include <wstring.h>
+#include "LCD_RTS.h"
+#include <WString.h>
 #include <stdio.h>
 #include <string.h>
 #include <Arduino.h>

--- a/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
+++ b/Marlin/src/lcd/e3v2/creality/LCD_RTS.h
@@ -2,7 +2,7 @@
 #define LCD_RTS_H
 
 #include "string.h"
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "../../../inc/MarlinConfig.h"
 


### PR DESCRIPTION
The firmware does not build on Linux due to incorrect case-sensitive includes.
This PR fixes the broken build.